### PR TITLE
Implement offline-first image display

### DIFF
--- a/src/components/MarkerModal.tsx
+++ b/src/components/MarkerModal.tsx
@@ -4,6 +4,7 @@ import UploadArea from './UploadArea';
 import CompareCanvas from './CompareCanvas';
 import CommunityWallPage from './CommunityWallPage';
 import ConfirmDialog from './ConfirmDialog';
+import OfflineImage from './OfflineImage';
 import './MarkerModal.css';
 import { composeImages } from '../utils/composeImages';
 import {
@@ -253,7 +254,12 @@ const MarkerModal: React.FC<Props> = ({ data, checkin, onClose, onUpdate, onUplo
                 )}
                 {status === 'withImage' && (
                   <div className="modal-preview-wrapper">
-                    <img src={getCacheBustingUrl(mergedUrl)} className="modal-preview" alt="对比图" />
+                    <OfflineImage
+                      markerId={data.id}
+                      url={getCacheBustingUrl(mergedUrl)}
+                      className="modal-preview"
+                      alt="对比图"
+                    />
                     <div className="modal-preview-buttons">
                       <button className="btn-primary" onClick={() => download(mergedUrl, `compare-${data.id}.jpg`)}>下载对比图</button>
                       <UploadArea onSelect={handleSelect} label="重新上传" className="btn-outline" />

--- a/src/components/OfflineImage.tsx
+++ b/src/components/OfflineImage.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+import { getHDImageFromLocal } from '../utils/compareImageManager';
+
+interface Props extends React.ImgHTMLAttributes<HTMLImageElement> {
+  markerId: string;
+  url?: string;
+}
+
+const OfflineImage: React.FC<Props> = ({ markerId, url, ...rest }) => {
+  const [src, setSrc] = useState<string | undefined>(url);
+
+  useEffect(() => {
+    setSrc(url);
+  }, [url]);
+
+  useEffect(() => {
+    if (!url && !navigator.onLine) {
+      getHDImageFromLocal(markerId).then(blob => {
+        if (blob) {
+          const objUrl = URL.createObjectURL(blob);
+          setSrc(objUrl);
+        }
+      });
+    }
+  }, [url, markerId]);
+
+  useEffect(() => {
+    return () => {
+      if (src && src.startsWith('blob:')) {
+        URL.revokeObjectURL(src);
+      }
+    };
+  }, [src]);
+
+  const handleError = async () => {
+    const blob = await getHDImageFromLocal(markerId);
+    if (blob) {
+      const objUrl = URL.createObjectURL(blob);
+      setSrc(objUrl);
+    }
+  };
+
+  return <img src={src} onError={handleError} {...rest} />;
+};
+
+export default OfflineImage;

--- a/src/components/SidebarHistory.tsx
+++ b/src/components/SidebarHistory.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import OfflineImage from './OfflineImage';
 import { Point, CheckinInfo } from '../types';
 import './SidebarHistory.css';
 
@@ -29,9 +30,10 @@ const SidebarHistory: React.FC<Props> = ({ points, checkins, onSelect }) => {
               tabIndex={0}
             >
               {checkins[point.id] && checkins[point.id].url ? (
-                <img
+                <OfflineImage
                   className="history-thumb"
-                  src={checkins[point.id].url}
+                  markerId={point.id}
+                  url={checkins[point.id].url}
                   alt={point.name}
                 />
               ) : (


### PR DESCRIPTION
## Summary
- implement `OfflineImage` component to fallback to local IndexedDB images when network fails
- use `OfflineImage` in `MarkerModal` preview
- use `OfflineImage` in history sidebar

## Testing
- `npm test -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687188f1aa608321b3693d99f1213283