### PR TITLE
Add offline fallback for history images

### DIFF
--- a/src/components/SidebarHistory.tsx
+++ b/src/components/SidebarHistory.tsx
@@ -29,7 +29,7 @@ const SidebarHistory: React.FC<Props> = ({ points, checkins, onSelect }) => {
               onClick={() => onSelect(point.id)}
               tabIndex={0}
             >
-              {checkins[point.id] && checkins[point.id].url ? (
+              {checkins[point.id] && checkins[point.id].hasImage ? (
                 <OfflineImage
                   className="history-thumb"
                   markerId={point.id}


### PR DESCRIPTION
## Summary
- show local images in the history sidebar even when no URL is stored

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68719eae7c9c83219cae2b8b28133378